### PR TITLE
PMC authority management

### DIFF
--- a/authority-strings/concepts.json
+++ b/authority-strings/concepts.json
@@ -1,0 +1,12 @@
+{
+    "local_string_map": {
+        "Pre--Raphaelitism": "pmc-pre-raphaelitism"
+    },
+    "authorities": [
+        {
+            "identifier": "pmc-pre-raphaelitism",
+            "type": "Concept",
+            "label": "Pre-Raphaelitism",
+            "loc": "sh85106392"
+        }
+}

--- a/authority-strings/concepts.json
+++ b/authority-strings/concepts.json
@@ -9,4 +9,5 @@
             "label": "Pre-Raphaelitism",
             "loc": "sh85106392"
         }
+    ]
 }

--- a/authority-strings/groups.json
+++ b/authority-strings/groups.json
@@ -160,8 +160,10 @@
         "University College London": "pmc-ucl",
         "UCL": "pmc-ucl",
 
-        "Americans": "pmc-americans"
+        "Americans": "pmc-americans",
 
+        "Fry Gallery": "pmc-fry-gallery",
+        "Fry Art Gallery, 1985-": "pmc-fry-gallery"
 
     },
     "authorities": [
@@ -429,6 +431,13 @@
             "type": "Group",
             "label": "Americans",
             "loc": "sh85004432"
+        },
+
+        {
+            "identifier": "pmc-fry-gallery",
+            "type": "Group",
+            "label": "Fry Gallery",
+            "loc": "nb2005018148"
         }
 
     ]

--- a/authority-strings/groups.json
+++ b/authority-strings/groups.json
@@ -158,9 +158,9 @@
         "Robinson, Fisher & Co": "pmc-robinson-fisher",
 
         "University College London": "pmc-ucl",
-        "UCL": "pmc-ucl"
+        "UCL": "pmc-ucl",
 
-
+        "Americans": "pmc-americans"
 
 
     },
@@ -422,6 +422,13 @@
             "label": "National Trust (Great Britain)",
             "loc": "n80085261",
             "viaf": "152285425"
+        },
+
+        {
+            "identifier": "pmc-americans",
+            "type": "Group",
+            "label": "Americans",
+            "loc": "sh85004432"
         }
 
     ]

--- a/authority-strings/people.json
+++ b/authority-strings/people.json
@@ -34,7 +34,10 @@
         "Ford, Richard Brinsley, 1908-": "pmc-brinsley-ford",
         "Ford, Brinsley, 1908-1999": "pmc-brinsley-ford",
         "Ford, Brinsley": "pmc-brinsley-ford",
-        "Sir (Richard) Brinsley Ford": "pmc-brinsley-ford"
+        "Sir (Richard) Brinsley Ford": "pmc-brinsley-ford",
+
+        "Haldin; Daphne Louise (18991973)": "pmc-daphne-haldin",
+        "Haldin, Daphne": "pmc-daphne-haldin"
 
     },
     "authorities": [
@@ -88,6 +91,13 @@
             "label": "Brinsley Ford",
             "loc": "no92029550",
             "viaf": "315522957"
+        },
+        
+        {
+            "identifier": "pmc-daphne-haldin",
+            "type": "Individual",
+            "label": "Daphne Haldin",
+            "wikidata": "Q24284452"
         }
 
     ]

--- a/authority-strings/people.json
+++ b/authority-strings/people.json
@@ -59,7 +59,12 @@
         "Sharp; Dennis Charles (1933-2010)": "pmc-dennis-sharp",
 
         "Waterfield, Humphrey": "pmc-humphrey-waterfield",
-        "Waterfield, Derick Humphrey": "pmc-humphrey-waterfield"
+        "Waterfield, Derick Humphrey": "pmc-humphrey-waterfield",
+
+        "Lucy Wertheim": "pmc-lucy-wertheim",
+        "Lucy Carrington Wertheim": "pmc-lucy-wertheim",
+        "Wertheim, Lucy Carrington": "pmc-lucy-wertheim",
+        "Wertheim, Lucy C.": "pmc-lucy-wertheim"
 
     },
     "authorities": [
@@ -164,6 +169,15 @@
             "type": "Individual",
             "label": "Humphrey Waterfield",
             "viaf": "13663955"
+        },
+        
+        {
+            "identifier": "pmc-lucy-wertheim",
+            "type": "Individual",
+            "label": "Lucy Wertheim",
+            "viaf": "68445913",
+            "loc": "nb2004301892"
         } 
+
     ]
 }

--- a/authority-strings/people.json
+++ b/authority-strings/people.json
@@ -41,7 +41,9 @@
 
         "John Ingamells": "pmc-john-ingamells",
         "John Ingamells, 1934-2013": "pmc-john-ingamells",
-        "John Anderson Stuart Ingamells": "pmc-john-ingamells"
+        "John Anderson Stuart Ingamells": "pmc-john-ingamells",
+
+        "Joyce, Paul R": "pmc-paul-joyce"
 
     },
     "authorities": [
@@ -110,7 +112,14 @@
             "label": "John Ingamells",
             "loc": "n83225898",
             "viaf": "9891237"
-        }
+        },
+
+        {
+            "identifier": "pmc-paul-joyce",
+            "type": "Individual",
+            "label": "Paul R. Joyce",
+            "wikidata": "Q48816170"
+        }   
 
     ]
 }

--- a/authority-strings/people.json
+++ b/authority-strings/people.json
@@ -1,9 +1,19 @@
 {
     "local_string_map": {
-        
+        "Hamilton, Alec": "pmc-alec-hamilton",
+        "Alec Hamilton": "pmc-alec-hamilton",
+        "Alec Hamilton": "pmc-alec-hamilton"
+        "Hamilton, Alec, 1949-": "pmc-alec-hamilton"
+        "Alexander Graham Hamilton": "pmc-alec-hamilton"
 
     },
     "authorities": [
-        
+        {
+            "identifier": "pmc-alec-hamilton",
+            "type": "Individual",
+            "label": "Alec Hamilton",
+            "viaf": "296806600",
+            "loc": "296806600"
+        } 
     ]
 }

--- a/authority-strings/people.json
+++ b/authority-strings/people.json
@@ -37,7 +37,11 @@
         "Sir (Richard) Brinsley Ford": "pmc-brinsley-ford",
 
         "Haldin; Daphne Louise (18991973)": "pmc-daphne-haldin",
-        "Haldin, Daphne": "pmc-daphne-haldin"
+        "Haldin, Daphne": "pmc-daphne-haldin",
+
+        "John Ingamells": "pmc-john-ingamells",
+        "John Ingamells, 1934-2013": "pmc-john-ingamells",
+        "John Anderson Stuart Ingamells": "pmc-john-ingamells"
 
     },
     "authorities": [
@@ -98,6 +102,14 @@
             "type": "Individual",
             "label": "Daphne Haldin",
             "wikidata": "Q24284452"
+        },
+
+        {
+            "identifier": "pmc-john-ingamells",
+            "type": "Individual",
+            "label": "John Ingamells",
+            "loc": "n83225898",
+            "viaf": "9891237"
         }
 
     ]

--- a/authority-strings/people.json
+++ b/authority-strings/people.json
@@ -52,7 +52,11 @@
 
         "Charles S. Rhyne": "pmc-charles-rhyne",
         "Rhyne, Charles, 1932-2013": "pmc-charles-rhyne",
-        "Rhyne, Charles S.": "pmc-charles-rhyne"
+        "Rhyne, Charles S.": "pmc-charles-rhyne",
+
+        "Dennis Sharp": "pmc-dennis-sharp",
+        "Dennis Sharp, 1933-2010": "pmc-dennis-sharp",
+        "Sharp; Dennis Charles (1933-2010)": "pmc-dennis-sharp"
 
     },
     "authorities": [
@@ -143,6 +147,13 @@
             "type": "Individual",
             "label": "Charles S. Rhyne",
             "viaf": "34300400"
-        } 
+        },
+        
+        {
+            "identifier": "pmc-dennis-sharp",
+            "type": "Individual",
+            "label": "Dennis Sharp",
+            "loc": "n50022232"
+        }     
     ]
 }

--- a/authority-strings/people.json
+++ b/authority-strings/people.json
@@ -43,7 +43,12 @@
         "John Ingamells, 1934-2013": "pmc-john-ingamells",
         "John Anderson Stuart Ingamells": "pmc-john-ingamells",
 
-        "Joyce, Paul R": "pmc-paul-joyce"
+        "Joyce, Paul R": "pmc-paul-joyce",
+
+        "Kerney, Michael, 1934-2022": "pmc-michael-kerney",
+        "Michael Kerney": "pmc-michael-kerney", 
+        "Michael P. Kerney": "pmc-michael-kerney",
+        "Dr Michael Kerney": "pmc-michael-kerney"
 
     },
     "authorities": [
@@ -119,7 +124,14 @@
             "type": "Individual",
             "label": "Paul R. Joyce",
             "wikidata": "Q48816170"
-        }   
+        },   
 
+        {
+            "identifier": "pmc-michael-kerney",
+            "type": "Individual",
+            "label": "Michael Kerney",
+            "viaf": "66634116",
+            "loc": "n83064447"
+        }
     ]
 }

--- a/authority-strings/people.json
+++ b/authority-strings/people.json
@@ -10,8 +10,14 @@
         "Auerbach": "pmc-auerbach",
         "Frank Auerbach": "pmc-auerbach",
         "F. Auerbach": "pmc-auerbach",
-        "Auerbach, Frank, 1931-": "pmc-auerbach"
+        "Auerbach, Frank, 1931-": "pmc-auerbach",
 
+        "Packer, William (author)": "pmc-william-packer",
+        "William John Packer (b.1940)": "pmc-william-packer",
+        "William John Packer": "pmc-william-packer",
+        "William J. Packer": "pmc-william-packer",
+        "William John Packer (1940-)":  "pmc-william-packer"
+    
     },
     "authorities": [
         {
@@ -28,7 +34,13 @@
             "label": "Frank Auerbach",
             "viaf": "22150864",
             "loc": "n83038772"
-        }
+        },
 
+        {
+            "identifier": "pmc-william-packer",
+            "type": "Individual",
+            "label": "William Packer",
+            "viaf": "113212618"
+        }
     ]
 }

--- a/authority-strings/people.json
+++ b/authority-strings/people.json
@@ -16,7 +16,10 @@
         "William John Packer (b.1940)": "pmc-william-packer",
         "William John Packer": "pmc-william-packer",
         "William J. Packer": "pmc-william-packer",
-        "William John Packer (1940-)":  "pmc-william-packer"
+        "William John Packer (1940-)":  "pmc-william-packer",
+
+        "Baker, Malcolm, 1945-, 1945-": "pmc-malcolm-baker",
+        "Baker, Malcolm, 1945-": "pmc-malcolm-baker"
     
     },
     "authorities": [
@@ -41,6 +44,13 @@
             "type": "Individual",
             "label": "William Packer",
             "viaf": "113212618"
-        }
+        },
+
+        {
+            "identifier": "pmc-malcolm-baker",
+            "type": "Individual",
+            "label": "Malcolm Baker",
+            "loc": "no2014117306"
+        } 
     ]
 }

--- a/authority-strings/people.json
+++ b/authority-strings/people.json
@@ -27,8 +27,15 @@
         "William George Constable, 1887-1976": "pmc-w-g-constable",
         "William George Constable (1887-1976)": "pmc-w-g-constable",
         "Constable, W. G. (William George), 1887-": "pmc-w-g-constable",   
-        "W. G. Constable": "pmc-w-g-constable"
-    
+        "W. G. Constable": "pmc-w-g-constable",
+
+        "Ford; Sir; Richard Brinsley (1908-1999), 1908-1999": "pmc-brinsley-ford",
+        "Ford; Sir; Richard Brinsley (1908-1999)": "pmc-brinsley-ford",
+        "Ford, Richard Brinsley, 1908-": "pmc-brinsley-ford",
+        "Ford, Brinsley, 1908-1999": "pmc-brinsley-ford",
+        "Ford, Brinsley": "pmc-brinsley-ford",
+        "Sir (Richard) Brinsley Ford": "pmc-brinsley-ford"
+
     },
     "authorities": [
         {
@@ -73,7 +80,15 @@
             "type": "Individual",
             "label": "W. G. Constable",
             "loc": "n80007765"
+        },
+
+        {
+            "identifier": "pmc-brinsley-ford",
+            "type": "Individual",
+            "label": "Brinsley Ford",
+            "loc": "no92029550",
+            "viaf": "315522957"
         }
-        
+
     ]
 }

--- a/authority-strings/people.json
+++ b/authority-strings/people.json
@@ -22,8 +22,12 @@
         "Baker, Malcolm, 1945-": "pmc-malcolm-baker",
 
         "Benthall; Gilbert (1880-1961), 1880-1961": "pmc-gilbert-benthall",
-        "Benthall, Gilbert": "pmc-gilbert-benthall"
+        "Benthall, Gilbert": "pmc-gilbert-benthall",
 
+        "William George Constable, 1887-1976": "pmc-w-g-constable",
+        "William George Constable (1887-1976)": "pmc-w-g-constable",
+        "Constable, W. G. (William George), 1887-": "pmc-w-g-constable",   
+        "W. G. Constable": "pmc-w-g-constable"
     
     },
     "authorities": [
@@ -62,6 +66,14 @@
             "type": "Individual",
             "label": "Gilbert Benthall",
             "wikidata": "Q106751849"
-        } 
+        },
+
+        {
+            "identifier": "pmc-w-g-constable",
+            "type": "Individual",
+            "label": "W. G. Constable",
+            "loc": "n80007765"
+        }
+        
     ]
 }

--- a/authority-strings/people.json
+++ b/authority-strings/people.json
@@ -48,7 +48,11 @@
         "Kerney, Michael, 1934-2022": "pmc-michael-kerney",
         "Michael Kerney": "pmc-michael-kerney", 
         "Michael P. Kerney": "pmc-michael-kerney",
-        "Dr Michael Kerney": "pmc-michael-kerney"
+        "Dr Michael Kerney": "pmc-michael-kerney",
+
+        "Charles S. Rhyne": "pmc-charles-rhyne",
+        "Rhyne, Charles, 1932-2013": "pmc-charles-rhyne",
+        "Rhyne, Charles S.": "pmc-charles-rhyne"
 
     },
     "authorities": [
@@ -132,6 +136,13 @@
             "label": "Michael Kerney",
             "viaf": "66634116",
             "loc": "n83064447"
-        }
+        },
+
+        {
+            "identifier": "pmc-charles-rhyne",
+            "type": "Individual",
+            "label": "Charles S. Rhyne",
+            "viaf": "34300400"
+        } 
     ]
 }

--- a/authority-strings/people.json
+++ b/authority-strings/people.json
@@ -2,9 +2,15 @@
     "local_string_map": {
         "Hamilton, Alec": "pmc-alec-hamilton",
         "Alec Hamilton": "pmc-alec-hamilton",
-        "Alec Hamilton": "pmc-alec-hamilton"
-        "Hamilton, Alec, 1949-": "pmc-alec-hamilton"
-        "Alexander Graham Hamilton": "pmc-alec-hamilton"
+        "Alec Hamilton": "pmc-alec-hamilton",
+        "Hamilton, Alec, 1949-": "pmc-alec-hamilton",
+        "Alexander Graham Hamilton": "pmc-alec-hamilton",
+
+        "Frank Helmut Auerbach, 1931-2024": "pmc-auerbach",
+        "Auerbach": "pmc-auerbach",
+        "Frank Auerbach": "pmc-auerbach",
+        "F. Auerbach": "pmc-auerbach",
+        "Auerbach, Frank, 1931-": "pmc-auerbach"
 
     },
     "authorities": [
@@ -14,6 +20,15 @@
             "label": "Alec Hamilton",
             "viaf": "296806600",
             "loc": "296806600"
-        } 
+        },
+        
+        {
+            "identifier": "pmc-auerbach",
+            "type": "Individual",
+            "label": "Frank Auerbach",
+            "viaf": "22150864",
+            "loc": "n83038772"
+        }
+
     ]
 }

--- a/authority-strings/people.json
+++ b/authority-strings/people.json
@@ -56,7 +56,10 @@
 
         "Dennis Sharp": "pmc-dennis-sharp",
         "Dennis Sharp, 1933-2010": "pmc-dennis-sharp",
-        "Sharp; Dennis Charles (1933-2010)": "pmc-dennis-sharp"
+        "Sharp; Dennis Charles (1933-2010)": "pmc-dennis-sharp",
+
+        "Waterfield, Humphrey": "pmc-humphrey-waterfield",
+        "Waterfield, Derick Humphrey": "pmc-humphrey-waterfield"
 
     },
     "authorities": [
@@ -154,6 +157,13 @@
             "type": "Individual",
             "label": "Dennis Sharp",
             "loc": "n50022232"
-        }     
+        },
+        
+        {
+            "identifier": "pmc-humphrey-waterfield",
+            "type": "Individual",
+            "label": "Humphrey Waterfield",
+            "viaf": "13663955"
+        } 
     ]
 }

--- a/authority-strings/people.json
+++ b/authority-strings/people.json
@@ -19,7 +19,11 @@
         "William John Packer (1940-)":  "pmc-william-packer",
 
         "Baker, Malcolm, 1945-, 1945-": "pmc-malcolm-baker",
-        "Baker, Malcolm, 1945-": "pmc-malcolm-baker"
+        "Baker, Malcolm, 1945-": "pmc-malcolm-baker",
+
+        "Benthall; Gilbert (1880-1961), 1880-1961": "pmc-gilbert-benthall",
+        "Benthall, Gilbert": "pmc-gilbert-benthall"
+
     
     },
     "authorities": [
@@ -51,6 +55,13 @@
             "type": "Individual",
             "label": "Malcolm Baker",
             "loc": "no2014117306"
+        },
+        
+        {
+            "identifier": "pmc-gilbert-benthall",
+            "type": "Individual",
+            "label": "Gilbert Benthall",
+            "wikidata": "Q106751849"
         } 
     ]
 }


### PR DESCRIPTION
- Added manual reconciliation for key figures across Library and Archive collections.
- Added document for management of concept authorities in addition to people and groups.